### PR TITLE
Add .mailmap file to get git-shortlog(1) right

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Richard Hartmann <richih@debian.org> <richih.mailinglist@gmail.com>
+Richard Hartmann <richih@debian.org> <RichiH@users.noreply.github.com>


### PR DESCRIPTION
The commit history contains several different email addresses for
Richard Hartmann, add .mailmap to map them all into one.
